### PR TITLE
Set up GitHub Action for PR Auto-Assignment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+# <- Add PR title ->
+
+<- Add a description ->
+
+## Metadata
+
+| Query                                        | Value                                                                                      |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Destination Branch                           | `<branch name>`                                                                            |
+| Design spec                                  | Figma link                                                                                 |
+| Change type                                  | `Architectural Change / New Feature / Bug Fix / Refactor Existing Code` <Pick one or more> |
+| Should reviewers manually test your changes? | `Yes/No` <Pick one>                                                                        |
+
+## Visual Aid
+
+<- Upload a screenshot or demo clip if necessary ->
+
+## Additional Information <Delete unnecessary points>
+
+### How Has This Been Tested?
+
+<- Add something if applies ->
+
+### Does similar functionality already exist in the codebase? If so, why isn’t this functionality reused?
+
+<- Add something if applies ->
+
+### Files with major changes / what is worth paying more attention to?
+
+<- Add something if applies ->
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project.
+- [ ] I have performed a self-review of my code.
+- [ ] I unit tested new methods.
+- [ ] I have commented my code, particularly in hard-to-understand areas.
+- [ ] My changes require changes in documentation and I have made the corresponding changes.

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -1,0 +1,14 @@
+name: Auto assign reviewer
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hkusu/review-assign-action@v1
+        with:
+          assignees: ${{ github.actor }} # assign pull request author
+          reviewers: sahanpd

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,3 +12,4 @@ jobs:
         with:
           assignees: ${{ github.actor }} # assign pull request author
           reviewers: sahanpd
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,3 +12,4 @@ jobs:
               with:
                   assignees: ${{ github.actor }} # assign pull request author
                   reviewers: sahanpd
+                  github-token: ${{ secrets.TOKEN }}

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -1,15 +1,15 @@
 name: Auto assign reviewer
 
 on:
-  pull_request:
-    types: [opened, ready_for_review]
+    pull_request:
+        types: [opened, ready_for_review]
 
 jobs:
-  assign:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: hkusu/review-assign-action@v1
-        with:
-          assignees: ${{ github.actor }} # assign pull request author
-          reviewers: sahanpd
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+    assign:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: hkusu/review-assign-action@v1
+              with:
+                  assignees: ${{ github.actor }} # assign pull request author
+                  reviewers: sahanpd
+                  github-token: ${{ secrets.TOKEN }}

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,4 +12,3 @@ jobs:
               with:
                   assignees: ${{ github.actor }} # assign pull request author
                   reviewers: sahanpd
-                  github-token: ${{ secrets.TOKEN }}


### PR DESCRIPTION
# Set up GitHub Action for PR Auto-Assignment

This PR sets up a GitHub Action workflow that automatically assigns the author of a pull request as the assignee and Mr. Sahan Dharmawardhana as the reviewer. The action is triggered whenever a new pull request is opened or marked as ready for review.

## Metadata

| Query                                        | Value                                                                                      |
| -------------------------------------------- | ------------------------------------------------------------------------------------------ |
| Destination Branch                           | `develop`                                                                            |
| Design spec                                  | [Figma](https://www.figma.com/file/Affmf8haXOxIUuoWNnwYqX/Frontend-Technical-Test---Wireapps?node-id=0%3A1)                                                                                 |
| Change type                                  | `Architectural Change` |
| Should reviewers manually test your changes? | `No`                                                                    |

## Additional Information <Delete unnecessary points>

### Does similar functionality already exist in the codebase? If so, why isn’t this functionality reused?

No

### Files with major changes / what is worth paying more attention to?

pr-auto-assign.yml

## Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my code.
- [ ] I unit tested new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes require changes in documentation and I have made the corresponding changes.
